### PR TITLE
🚑 hotfix: restore missing NoMatchingDataException to fix build error

### DIFF
--- a/src/main/java/app/handong/feed/exception/data/DuplicateTagCodeException.java
+++ b/src/main/java/app/handong/feed/exception/data/DuplicateTagCodeException.java
@@ -1,7 +1,17 @@
 package app.handong.feed.exception.data;
 
-public class DuplicateTagCodeException extends RuntimeException {
+import lombok.NoArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
 
+/**
+ * 태그 생성시 중복 태그코드 (태그의 PK) 발생한 경우 사용되는 예외처리
+ * HttpStatus CONFLICT
+ */
+@ResponseStatus(value = HttpStatus.CONFLICT)
+@SuppressWarnings("serial")
+@NoArgsConstructor
+public class DuplicateTagCodeException extends RuntimeException {
     public DuplicateTagCodeException(String code) {
         super("이미 존재하는 태그 코드입니다: " + code);
     }


### PR DESCRIPTION
`NoMatchingDataException.java` 파일의 삭제를 명시적으로 커밋 한적은 없습니다만, 삭제 이후에 다른파일 커밋 시 따라 커밋이 되는 문제가 있었습니다.
해서, workflow 빌드 에러가 발생하였고, 본 PR은 `NoMatchingDataException.java` 를 다시 생성한 버전입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
  - 중복 태그 관련 오류 발생 시, 앱이 명확한 충돌 응답(HTTP 409 상태 코드)을 반환하도록 개선했습니다.  
    이 변경으로 사용자에게 에러 상황이 보다 일관되고 명확하게 전달되어, 문제 인식 및 해결 과정이 개선됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->