### PR TITLE
♻️ refactor: unify NotFound-related exceptions and clean up references

### DIFF
--- a/src/main/java/app/handong/feed/exception/GlobalExceptionHandler.java
+++ b/src/main/java/app/handong/feed/exception/GlobalExceptionHandler.java
@@ -5,11 +5,9 @@ import app.handong.feed.exception.auth.NoAuthenticatedException;
 import app.handong.feed.exception.auth.NoAuthorizationException;
 import app.handong.feed.exception.data.DuplicateEntityException;
 import app.handong.feed.exception.data.DuplicateTagCodeException;
-import app.handong.feed.exception.data.NoMatchingDataException;
 import app.handong.feed.exception.data.NotFoundException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.jmx.access.InvalidInvocationException;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -27,7 +25,6 @@ public class GlobalExceptionHandler {
             NoAuthorizationException.class,
             DuplicateEntityException.class,
             DuplicateTagCodeException.class,
-            NoMatchingDataException.class,
             NotFoundException.class,
     })
     public ResponseEntity<Map<String, Object>> handleCustomExceptions(Exception ex) {

--- a/src/main/java/app/handong/feed/exception/data/DuplicateEntityException.java
+++ b/src/main/java/app/handong/feed/exception/data/DuplicateEntityException.java
@@ -4,13 +4,13 @@ import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-//2024-07-03 추가(클래스 처음 추가함)
 
 /**
- * 해당 메서드 권한 없을 경우 사용되는 예외처리
- * HttpStatus FORBIDDEN
+ * 중복 엔티티 발생한 경우 사용되는 예외처리
+ * HttpStatus CONFLICT
  */
 @ResponseStatus(value = HttpStatus.CONFLICT)
+@SuppressWarnings("serial")
 @NoArgsConstructor
 public class DuplicateEntityException extends RuntimeException {
     public DuplicateEntityException(String message) {

--- a/src/main/java/app/handong/feed/exception/data/NotFoundException.java
+++ b/src/main/java/app/handong/feed/exception/data/NotFoundException.java
@@ -4,13 +4,12 @@ import lombok.NoArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-//2024-07-03 추가(클래스 처음 추가함)
-
 /**
- * 해당 메서드 권한 없을 경우 사용되는 예외처리
- * HttpStatus FORBIDDEN
+ *  찾으려고 하는 Data가 없을 때 사용되는 예외처리
+ *  HttpStatus 404
  */
 @ResponseStatus(value = HttpStatus.NOT_FOUND)
+@SuppressWarnings("serial")
 @NoArgsConstructor
 public class NotFoundException extends RuntimeException {
     public NotFoundException(String message) {

--- a/src/main/java/app/handong/feed/service/impl/TagServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/TagServiceImpl.java
@@ -3,7 +3,7 @@ package app.handong.feed.service.impl;
 import app.handong.feed.domain.Tag;
 import app.handong.feed.dto.TagDto;
 import app.handong.feed.exception.data.DuplicateTagCodeException;
-import app.handong.feed.exception.data.NoMatchingDataException;
+import app.handong.feed.exception.data.NotFoundException;
 import app.handong.feed.repository.TagRepository;
 import app.handong.feed.service.TagService;
 import org.springframework.transaction.annotation.Transactional;
@@ -50,7 +50,7 @@ public class TagServiceImpl implements TagService {
     @Transactional(readOnly = true)
     public TagDto.ReadResDto readTag(String code) {
         Tag tag = tagRepository.findById(code)
-                .orElseThrow(() -> new NoMatchingDataException("Tag not found with code: " + code));
+                .orElseThrow(() -> new NotFoundException("Tag not found with code: " + code));
 
         return new TagDto.ReadResDto(
                 tag.getCode(),
@@ -85,7 +85,7 @@ public class TagServiceImpl implements TagService {
     @Transactional
     public TagDto.UpdateResDto updateTag(String code, TagDto.UpdateReqDto dto) {
         Tag tag = tagRepository.findById(code)
-                .orElseThrow(() -> new NoMatchingDataException("Tag not found with code: " + code));
+                .orElseThrow(() -> new NotFoundException("Tag not found with code: " + code));
 
         // 필드 업데이트
         tag.setLabel(dto.getLabel());
@@ -108,7 +108,7 @@ public class TagServiceImpl implements TagService {
     @Override
     public TagDto.DeleteResDto deleteTag(String code) {
         tagRepository.findById(code)
-            .orElseThrow(() -> new NoMatchingDataException("Tag not found with code: " + code));
+            .orElseThrow(() -> new NotFoundException("Tag not found with code: " + code));
 
         tagRepository.deleteById(code);
         return new TagDto.DeleteResDto(code, "Tag deleted successfully");


### PR DESCRIPTION
## 작업 내용

- `NoMatchingDataException` 제거 및 `NotFoundException`으로 대체
- `GlobalExceptionHandler`, `TagServiceImpl` 등 참조 코드 정리
- 중복 예외 역할 정리 및 불필요한 예외 제거
- 각 예외 클래스에 JavaDoc 추가
- `@SuppressWarnings("serial")` 추가로 빌드/IDE 경고 제거

## 목적

- 404 관련 예외의 중복 처리 제거
- 예외 처리 로직 일관성 향상
- 코드 가독성과 유지보수성 개선

## 관련 커밋
- 🔥 chore: remove NoMatchingDataException reference from GlobalExceptionHandler
- 📝 docs: add Javadoc to NotFoundException and replace NoMatchingDataException in TagServiceImpl
- 📝 docs: add Javadoc and suppress serial warning in DuplicateEntityException

## 관련 이슈
resolves #97 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **버그 수정**
	- 오동작 시 반환되는 HTTP 상태 코드가 개선되어, 중복 데이터 상황에서 409 Conflict, 등록되지 않은 항목의 경우 404 Not Found 응답을 제공합니다.
  
- **리펙토링**
	- 오류 처리 흐름을 정리하여 불필요한 예외 처리를 제거하고, 사용자에게 보다 명확한 오류 피드백을 전달하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->