### PR TITLE
Add GitHub Actions workflow for PR build testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
       # JDK 17 설정한당
       # temurin = Adoptium에서 제공하는 JDK
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,0 +1,40 @@
+name: Test PR Build (Spring Boot)
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths-ignore:
+      - '**/*.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: "pr-build"
+  cancel-in-progress: true
+
+jobs:
+  test-build:
+    runs-on: ubuntu-latest
+
+    environment: SPRING_BOOT
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@v2.6.0
+        with:
+          arguments: build
+        env:
+          REACT_APP_WEATHER_KEY: ${{ secrets.VITE_WEATHER_KEY }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -18,8 +18,6 @@ jobs:
   test-build:
     runs-on: ubuntu-latest
 
-    environment: SPRING_BOOT
-
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'


### PR DESCRIPTION
### 📋 설명  
Spring Boot 애플리케이션의 PR에 대해 자동으로 빌드를 실행하는 GitHub Actions 워크플로우를 추가했습니다.

- **트리거**: `main` 브랜치로의 Pull Request 생성 시
- **기능**:
  - JDK 17 설정
  - Gradle 빌드 수행 (`./gradlew build`)
  - `.md` 파일 변경은 무시
- **제외사항**:
  - 릴리즈 생성 및 아티팩트 업로드는 포함되지 않음 (PR 테스트 용도이므로)

---

### 🧪 목적  
PR에서 코드 변경 시 자동으로 빌드를 실행해 문제 여부를 빠르게 확인하고, 안정적인 병합을 유도합니다.

---

### ✅ 참고  
- 향후 테스트 결과 업로드, 정적 분석, 코드 포맷 검사 등도 연동 가능
- 릴리즈 워크플로우(`main` push 기반)와는 별도로 동작


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chore**
	- 변경사항의 검증 및 빌드 과정을 자동화하는 새로운 작업 흐름을 도입하였습니다. 이 프로세스는 제출된 변경사항에 대해 자동 테스트와 빌드 단계를 실행함으로써 프로젝트의 안정성과 품질 관리가 강화되었습니다. 이를 통해 개발 시 효율성과 신뢰성이 한층 향상될 것으로 기대됩니다.
	- GitHub Actions에서 JDK 설정을 위한 액션 버전을 v3에서 v4로 업데이트하였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->