### PR TITLE
chore: `NO_FRONT_BUILD` to skip react build process

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,7 +67,15 @@ sourceSets {
     }
 }
 
-processResources { dependsOn "copyReactBuildFiles" }
+processResources {
+    // NO_FRONT_BUILD 환경 변수가 '1'이 아닌 경우에만 frontend 빌드 의존성 추가
+    if (System.getenv("NO_FRONT_BUILD") != '1') {
+        println "NO_FRONT_BUILD is not set or not '1'. Adding dependency on copyReactBuildFiles."
+        dependsOn "copyReactBuildFiles"
+    } else {
+        println "NO_FRONT_BUILD=1 detected. Skipping dependency on copyReactBuildFiles."
+    }
+}
 
 task installReact(type: Exec) {
     workingDir "$frontendDir"


### PR DESCRIPTION
백엔드 개발시 프론트엔드 빌드로 인해 개발이 오래걸리는 현상을 방지하고자 `NO_FRONT_BUILD=1` 환경변수를 추가하였습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - 빌드 프로세스가 환경 변수에 따라 프론트엔드 빌드 작업의 자동 실행 여부를 관리하도록 개선되었습니다. 이 변경으로 개발 및 배포 시 보다 유연하고 효율적인 빌드 환경을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->