### PR TITLE
♻️ refactor: api key schema

### DIFF
--- a/.bruno/Feed/Admin/issue api key.bru
+++ b/.bruno/Feed/Admin/issue api key.bru
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-    "owner": "Spotlight-LLM",
+    "description": "for Spotlight-LLM",
     "scopes": [
       "tag:read",
       "tb-subject-tag:create"

--- a/src/main/java/app/handong/feed/domain/ApiKey.java
+++ b/src/main/java/app/handong/feed/domain/ApiKey.java
@@ -19,7 +19,7 @@ import java.util.UUID;
 public class ApiKey {
 
     @Id
-    @Column(columnDefinition = "varchar(32)")
+    @Column(columnDefinition = "char(32)")
     private String id; // UUID
 
     @Column(name = "api_key_hash", nullable = false, columnDefinition = "char(64)")

--- a/src/main/java/app/handong/feed/domain/ApiKey.java
+++ b/src/main/java/app/handong/feed/domain/ApiKey.java
@@ -9,6 +9,7 @@ import lombok.Setter;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -17,13 +18,17 @@ import java.util.List;
 @Table(name = "api_keys")
 public class ApiKey {
 
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Id
+    @Column(columnDefinition = "varchar(32)")
+    private String id; // UUID
 
     @Column(name = "api_key_hash", nullable = false, columnDefinition = "char(64)")
     private String apiKeyHash;
 
-    private String owner;
+    private String description;
+
+    @Column(columnDefinition = "varchar(32)")
+    private String issuedBy;
 
     private LocalDateTime createdAt = LocalDateTime.now();
     private LocalDateTime lastUsedAt;
@@ -37,6 +42,13 @@ public class ApiKey {
 
     public void addScope(String scopeName) {
         this.scopes.add(new ApiKeyScope(this, scopeName));
+    }
+
+    @PrePersist
+    public void onPrePersist() {
+        if (this.id == null || this.id.isEmpty()) {
+            this.id = UUID.randomUUID().toString().replace("-", "");
+        }
     }
 
 }

--- a/src/main/java/app/handong/feed/domain/ApiKeyScope.java
+++ b/src/main/java/app/handong/feed/domain/ApiKeyScope.java
@@ -3,13 +3,15 @@ package app.handong.feed.domain;
 import jakarta.persistence.*;
 import lombok.Getter;
 
+import java.util.UUID;
+
 @Entity
 @Getter
 @Table(name = "api_key_scopes")
 public class ApiKeyScope {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    @Column(columnDefinition = "varchar(32)")
+    private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "api_key_id", nullable = false, foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT))
@@ -23,6 +25,13 @@ public class ApiKeyScope {
     public ApiKeyScope(ApiKey apiKey, String scope) {
         this.apiKey = apiKey;
         this.scope = scope;
+    }
+
+    @PrePersist
+    public void onPrePersist() {
+        if (this.id == null || this.id.isEmpty()) {
+            this.id = UUID.randomUUID().toString().replace("-", "");
+        }
     }
 
 }

--- a/src/main/java/app/handong/feed/domain/ApiKeyScope.java
+++ b/src/main/java/app/handong/feed/domain/ApiKeyScope.java
@@ -10,7 +10,7 @@ import java.util.UUID;
 @Table(name = "api_key_scopes")
 public class ApiKeyScope {
     @Id
-    @Column(columnDefinition = "varchar(32)")
+    @Column(columnDefinition = "char(32)")
     private String id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/app/handong/feed/dto/TbadminDto.java
+++ b/src/main/java/app/handong/feed/dto/TbadminDto.java
@@ -30,8 +30,8 @@ public class TbadminDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ApiKeyCreateReqDto {
-        @Schema(description = "API 키 소유자", example = "spotlight")
-        private String owner;
+        @Schema(description = "API Key의 정보", example = "spotlight")
+        private String description;
 
         @Schema(description = "허용된 스코프 목록", example = "[\"tag:create\", \"tag:delete\"]")
         private List<String> scopes = new ArrayList<>();
@@ -54,8 +54,9 @@ public class TbadminDto {
     @AllArgsConstructor
     @NoArgsConstructor
     public static class ApiKeyDetail {
-        private Long id;
-        private String owner;
+        private String id;
+        private String description;
+        private String issuedBy;
         private boolean isActive;
         private LocalDateTime createdAt;
         private LocalDateTime lastUsedAt;

--- a/src/main/java/app/handong/feed/service/impl/TbadminServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/TbadminServiceImpl.java
@@ -66,7 +66,8 @@ public class TbadminServiceImpl implements TbadminService {
 
         ApiKey apiKey = ApiKey.builder()
                 .apiKeyHash(hashedKey)
-                .owner(req.getOwner())
+                .description(req.getDescription())
+                .issuedBy(userId)
                 .createdAt(LocalDateTime.now())
                 .isActive(true)
                 .build();
@@ -100,7 +101,8 @@ public class TbadminServiceImpl implements TbadminService {
 
         return new TbadminDto.ApiKeyDetail(
                 apiKey.getId(),
-                apiKey.getOwner(),
+                apiKey.getDescription(),
+                apiKey.getIssuedBy(),
                 apiKey.isActive(),
                 apiKey.getCreatedAt(),
                 apiKey.getLastUsedAt(),


### PR DESCRIPTION
## 주요 변경 사항

API-Key 관리 도메인 구조를 ERD에 맞춰 리팩토링하였습니다.
![image](https://github.com/user-attachments/assets/ad3f4e10-a68a-4702-a917-04d337f4fdca)


### 엔티티 변경
- `ApiKey`
  - 기본 키를 `Long` → `UUID (String)`로 변경
  - `owner` → `description`으로 필드명 변경
  - `issuedBy` 필드 추가 (발급자 ID 저장)

- `ApiKeyScope`
  - 기본 키를 `Long` → `UUID (String)`로 변경
  - `api_key_id` 필드 타입 및 매핑 수정

### DTO 변경
- `ApiKeyCreateReqDto` 및 `ApiKeyDetail` 등 응답/요청 필드명을 스키마와 일치하도록 수정

### 서비스 로직 수정
- `issueApiKey`, `toggleApiKeyStatus` 등 UUID 기반 키 생성 및 저장 로직 적용
- 수동 UUID 생성 처리 추가

### 기타
- API-Key 발급 요청 (bruno) 바디 구조 변경 (`owner` → `description` 반영)

## 관련 이슈
resolves #113 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **새로운 기능**
  - API 키 생성 시 소유자 대신 상세 설명 및 발급자 정보가 제공됩니다.
- **개선 사항**
  - API 키 정보가 보다 명확하게 전달되도록 데이터 필드가 개선되었습니다.
  - 식별자 체계가 변경되어, 숫자 대신 UUID 기반의 문자열 식별자가 사용됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->