### PR TITLE
[BE] feat: update lastUsedAt field only when API key access is authorized

### DIFF
--- a/src/main/java/app/handong/feed/domain/ApiKey.java
+++ b/src/main/java/app/handong/feed/domain/ApiKey.java
@@ -51,4 +51,8 @@ public class ApiKey {
         }
     }
 
+    public void updateLastUsedAt() {
+        this.lastUsedAt = LocalDateTime.now();
+    }
+
 }


### PR DESCRIPTION
## 주요 변경 사항

### ApiKey 엔티티
- `updateLastUsedAt()` 메서드 추가
  - `lastUsedAt` 필드 업데이트 책임을 도메인 내부로 이동
  - 재사용 가능성 및 가독성 향상

### ApiKeyAuthInterceptor
- `@RequiredScopes` 검증 **성공 이후**에만 `lastUsedAt` 업데이트
  - 인증 헤더는 맞지만 권한이 부족한 요청은 기록하지 않도록 조치
  - 실제 "사용이 승인된 API 호출"만을 추적

## 관련 이슈
resolves #115 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새로운 기능**
  - API 키 사용 기록이 최신 상태로 유지되도록 마지막 사용 시점이 자동 갱신됩니다.

- **리팩토링**
  - 인증 과정에서 API 키 처리 로직이 간소화되어 효율성과 유지보수성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->