### PR TITLE
fix(server): preserve existing priority when null is passed during tag update

### DIFF
--- a/src/main/java/app/handong/feed/dto/TagDto.java
+++ b/src/main/java/app/handong/feed/dto/TagDto.java
@@ -38,7 +38,7 @@ public class TagDto {
         @Size(min = 6, max = 6)
         private String colorHex;
 
-        private float priorityWeight;
+        private Float priorityWeight;
 
         public Tag toEntity() {
             return new Tag(code, label, userDesc, llmDesc, colorHex, priorityWeight);
@@ -56,7 +56,7 @@ public class TagDto {
         private String userDesc;
         private String llmDesc;
         private String colorHex;
-        private float priorityWeight;
+        private Float priorityWeight;
         private LocalDateTime createdAt;
 
         public static CreateResDto fromEntity(Tag tag) {
@@ -79,7 +79,7 @@ public class TagDto {
         private String userDesc;
         private String llmDesc;
         private String colorHex;
-        private float priorityWeight;
+        private Float priorityWeight;
     }
 
     @Getter
@@ -91,7 +91,7 @@ public class TagDto {
         private String userDesc;
         private String llmDesc;
         private String colorHex;
-        private float priorityWeight;
+        private Float priorityWeight;
         private LocalDateTime updatedAt;
     }
 
@@ -104,7 +104,7 @@ public class TagDto {
         private String userDesc;
         private String llmDesc;
         private String colorHex;
-        private float priorityWeight;
+        private Float priorityWeight;
         private LocalDateTime createdAt;
         private LocalDateTime updatedAt;
     }

--- a/src/main/java/app/handong/feed/service/impl/TbadminServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/TbadminServiceImpl.java
@@ -168,7 +168,7 @@ public class TbadminServiceImpl implements TbadminService {
         Optional.ofNullable(dto.getUserDesc()).ifPresent(tag::setUserDesc);
         Optional.ofNullable(dto.getLlmDesc()).ifPresent(tag::setLlmDesc);
         Optional.ofNullable(dto.getColorHex()).ifPresent(tag::setColorHex);
-        Optional.of(dto.getPriorityWeight()).ifPresent(tag::setPriorityWeight);
+        Optional.ofNullable(dto.getPriorityWeight()).ifPresent(tag::setPriorityWeight);
 
         return new TagDto.UpdateResDto(
                 tag.getCode(),


### PR DESCRIPTION
기존 코드에서 dto.getPriorityWeight()를 Optional.of(...)로 처리하면서,
null 값이 전달되면 의도치 않게 우선순위가 0으로 설정되는 문제가 있었음.
이를 Optional.ofNullable(...)로 수정하여 null이 전달될 경우 기존 값을 유지하도록 수정함.

영향 범위:
- 관리자 페이지에서 태그 수정 시, 우선순위를 변경하지 않으면 기존 값이 그대로 유지됨

추가 확인 사항:
- 우선순위 값이 정상적으로 변경 및 유지되는지 확인 완료

fixes #130