### PR TITLE
Add tag information to feed data and display tags on frontend cards

### DIFF
--- a/.bruno/Feed/Admin/ApiKey/get all.bru
+++ b/.bruno/Feed/Admin/ApiKey/get all.bru
@@ -9,3 +9,50 @@ get {
   body: none
   auth: inherit
 }
+
+tests {
+  test("each item should exactly match the expected structure including nested issuedBy", function () {
+    const data = res.getBody();
+  
+    const expectedShape = {
+      id: 'string',
+      description: 'string',
+      issuedBy: {
+        id: 'string',
+        name: 'string',
+        createdAt: 'string',
+        lastLoginTime: 'string',
+        lastReadTime: 'string'
+      },
+      createdAt: 'string',
+      lastUsedAt: 'string',
+      scopes: 'array',
+      active: 'boolean'
+    };
+  
+    function validateStructure(obj, shape, path = '') {
+      const actualKeys = Object.keys(obj).sort();
+      const expectedKeys = Object.keys(shape).sort();
+      expect(actualKeys, `Keys at '${path || 'root'}' do not match`).to.eql(expectedKeys);
+  
+      for (const [key, typeOrShape] of Object.entries(shape)) {
+        const fullPath = path ? `${path}.${key}` : key;
+        const value = obj[key];
+  
+        if (typeof typeOrShape === 'string') {
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape}`).to.be.a(typeOrShape);
+        } else {
+          expect(value, `Field '${fullPath}' should be an object`).to.be.a('object');
+          validateStructure(value, typeOrShape, fullPath);
+        }
+      }
+    }
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      validateStructure(item, expectedShape, `item[${index}]`);
+    });
+  });
+  
+}

--- a/.bruno/Feed/Admin/Tag/Get Subject Tags (Admin).bru
+++ b/.bruno/Feed/Admin/Tag/Get Subject Tags (Admin).bru
@@ -13,3 +13,39 @@ get {
 params:path {
   subjectId: 1
 }
+
+assert {
+  res.body: isArray
+}
+
+tests {
+  test("each item should match expected structure exactly", function () {
+    const data = res.getBody(); // 이미 JSON 파싱되어 있다고 했으니 그대로 사용
+    const expectedKeys = [
+      'id', 'tbSubjectId', 'tagCode', 'tagData',
+      'confidentValue', 'forDate', 'updatedBy',
+      'createdAt', 'updatedAt'
+    ];
+  
+    const tagDataKeys = [
+      'code', 'label', 'userDesc', 'llmDesc',
+      'colorHex', 'priorityWeight', 'createdAt', 'updatedAt'
+    ];
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      // top-level key 정확히 일치
+      const actualKeys = Object.keys(item).sort();
+      expect(actualKeys, `Top-level keys at index ${index} do not match`)
+        .to.eql(expectedKeys.slice().sort());
+  
+      // tagData 구조 확인
+      expect(item.tagData).to.be.a('object');
+      const actualTagDataKeys = Object.keys(item.tagData).sort();
+      expect(actualTagDataKeys, `tagData keys at index ${index} do not match`)
+        .to.eql(tagDataKeys.slice().sort());
+    });
+  });
+  
+}

--- a/.bruno/Feed/Admin/Users/All Users.bru
+++ b/.bruno/Feed/Admin/Users/All Users.bru
@@ -9,3 +9,52 @@ get {
   body: none
   auth: inherit
 }
+
+tests {
+  test("each item should exactly match the expected user structure (nullable supported)", function () {
+    const data = res.getBody();
+  
+    const expectedShape = {
+      id: 'string',
+      name: 'string',
+      createdAt: 'string',
+      lastLoginTime: 'string',
+      lastReadTime: { type: 'string', nullable: true }
+    };
+  
+    function validateStructure(obj, shape, path = '') {
+      const actualKeys = Object.keys(obj).sort();
+      const expectedKeys = Object.keys(shape).sort();
+      expect(actualKeys, `Keys at '${path || 'root'}' do not match`).to.eql(expectedKeys);
+  
+      for (const [key, typeOrShape] of Object.entries(shape)) {
+        const fullPath = path ? `${path}.${key}` : key;
+        const value = obj[key];
+  
+        // Nullable 필드 처리
+        if (typeof typeOrShape === 'object' && typeOrShape.nullable) {
+          if (value === null) continue; // null 허용됨
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape.type} or null`).to.be.a(typeOrShape.type);
+        }
+  
+        // 일반 타입 문자열
+        else if (typeof typeOrShape === 'string') {
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape}`).to.be.a(typeOrShape);
+        }
+  
+        // 중첩된 객체 재귀
+        else {
+          expect(value, `Field '${fullPath}' should be an object`).to.be.a('object');
+          validateStructure(value, typeOrShape, fullPath);
+        }
+      }
+    }
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      validateStructure(item, expectedShape, `item[${index}]`);
+    });
+  });
+  
+}

--- a/.bruno/Feed/External/feed/ReadFeed.bru
+++ b/.bruno/Feed/External/feed/ReadFeed.bru
@@ -17,6 +17,59 @@ params:query {
   isFilterNew: 1
 }
 
+tests {
+  test("each item should exactly match the expected external feed structure", function () {
+    const data = res.getBody();
+  
+    const expectedShape = {
+      subjectId: 'number',
+      id: 'string',
+      sentAt: 'number',
+      message: 'string',
+      files: { type: 'array', nullable: true },
+      like: 'boolean',
+      messageCount: 'number',
+      tags: { type: 'array', nullable: true }
+    };
+  
+  
+    function validateStructure(obj, shape, path = '') {
+      const actualKeys = Object.keys(obj).sort();
+      const expectedKeys = Object.keys(shape).sort();
+      expect(actualKeys, `Keys at '${path || 'root'}' do not match`).to.eql(expectedKeys);
+  
+      for (const [key, typeOrShape] of Object.entries(shape)) {
+        const fullPath = path ? `${path}.${key}` : key;
+        const value = obj[key];
+  
+        // Nullable 필드 처리
+        if (typeof typeOrShape === 'object' && typeOrShape.nullable) {
+          if (value === null) continue; // null 허용됨
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape.type} or null`).to.be.a(typeOrShape.type);
+        }
+  
+        // 일반 타입 문자열
+        else if (typeof typeOrShape === 'string') {
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape}`).to.be.a(typeOrShape);
+        }
+  
+        // 중첩된 객체 재귀
+        else {
+          expect(value, `Field '${fullPath}' should be an object`).to.be.a('object');
+          validateStructure(value, typeOrShape, fullPath);
+        }
+      }
+    }
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      validateStructure(item, expectedShape, `item[${index}]`);
+    });
+  });
+  
+}
+
 docs {
   ## ✅ 파라미터 설명 테이블
   

--- a/.bruno/Feed/External/tag/List Tag.bru
+++ b/.bruno/Feed/External/tag/List Tag.bru
@@ -13,3 +13,57 @@ get {
 assert {
   res.body: isArray
 }
+
+tests {
+  test("each item should exactly match the external tag list structure", function () {
+    const data = res.getBody();
+  
+    const expectedShape = {
+      code: 'string',
+      label: 'string',
+      userDesc: 'string',
+      llmDesc: 'string',
+      colorHex: 'string',
+      priorityWeight: 'number',
+      createdAt: 'string',
+      updatedAt: 'string'
+    };
+  
+  
+  
+    function validateStructure(obj, shape, path = '') {
+      const actualKeys = Object.keys(obj).sort();
+      const expectedKeys = Object.keys(shape).sort();
+      expect(actualKeys, `Keys at '${path || 'root'}' do not match`).to.eql(expectedKeys);
+  
+      for (const [key, typeOrShape] of Object.entries(shape)) {
+        const fullPath = path ? `${path}.${key}` : key;
+        const value = obj[key];
+  
+        // Nullable 필드 처리
+        if (typeof typeOrShape === 'object' && typeOrShape.nullable) {
+          if (value === null) continue; // null 허용됨
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape.type} or null`).to.be.a(typeOrShape.type);
+        }
+  
+        // 일반 타입 문자열
+        else if (typeof typeOrShape === 'string') {
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape}`).to.be.a(typeOrShape);
+        }
+  
+        // 중첩된 객체 재귀
+        else {
+          expect(value, `Field '${fullPath}' should be an object`).to.be.a('object');
+          validateStructure(value, typeOrShape, fullPath);
+        }
+      }
+    }
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      validateStructure(item, expectedShape, `item[${index}]`);
+    });
+  });
+  
+}

--- a/.bruno/Feed/GetOne.bru
+++ b/.bruno/Feed/GetOne.bru
@@ -1,0 +1,56 @@
+meta {
+  name: GetOne
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:{{PORT}}/api/kafeed/get/:feedId
+  body: none
+  auth: inherit
+}
+
+params:path {
+  feedId: e28b9dd94c704847a3ca067a948f2e70
+}
+
+tests {
+  test("each item should exactly match the expected structure (message item)", function () {
+    const data = res.getBody(); // 이미 파싱된 객체
+    const expectedShape = {
+      subjectId: 'number',
+      id: 'string',
+      sentAt: 'number',
+      message: 'string',
+      files: 'array',
+      like: 'boolean',
+      messageCount: 'number',
+      tags: 'array'
+    };
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      // 키 목록 정확히 일치
+      const actualKeys = Object.keys(item).sort();
+      const expectedKeys = Object.keys(expectedShape).sort();
+  
+      expect(actualKeys, `Keys at index ${index} do not match expected keys`)
+        .to.eql(expectedKeys);
+  
+      // 각 필드 타입 확인
+      for (const [key, type] of Object.entries(expectedShape)) {
+        const value = item[key];
+        expect(value, `Field '${key}' at index ${index} should be a ${type}`).to.be.a(type);
+      }
+    });
+  });
+  
+}
+
+docs {
+  ### type
+  * like
+  * unseen
+  * all
+}

--- a/.bruno/Feed/scrolllist(unread).bru
+++ b/.bruno/Feed/scrolllist(unread).bru
@@ -5,12 +5,53 @@ meta {
 }
 
 get {
-  url: http://localhost:{{PORT}}/api/kafeed/scrolllist?afterSentAt=-1&type=unseen
+  url: http://localhost:{{PORT}}/api/kafeed/scrolllist?afterSentAt=-1&type=all
   body: none
-  auth: none
+  auth: inherit
 }
 
 params:query {
   afterSentAt: -1
-  type: unseen
+  type: all
+}
+
+tests {
+  test("each item should exactly match the expected structure (message item)", function () {
+    const data = res.getBody(); // 이미 파싱된 객체
+    const expectedShape = {
+      subjectId: 'number',
+      id: 'string',
+      sentAt: 'number',
+      message: 'string',
+      files: 'array',
+      like: 'boolean',
+      messageCount: 'number',
+      tags: 'array'
+    };
+  
+    expect(data).to.be.a('array');
+  
+    data.forEach((item, index) => {
+      // 키 목록 정확히 일치
+      const actualKeys = Object.keys(item).sort();
+      const expectedKeys = Object.keys(expectedShape).sort();
+  
+      expect(actualKeys, `Keys at index ${index} do not match expected keys`)
+        .to.eql(expectedKeys);
+  
+      // 각 필드 타입 확인
+      for (const [key, type] of Object.entries(expectedShape)) {
+        const value = item[key];
+        expect(value, `Field '${key}' at index ${index} should be a ${type}`).to.be.a(type);
+      }
+    });
+  });
+  
+}
+
+docs {
+  ### type
+  * like
+  * unseen
+  * all
 }

--- a/src/main/front/src/components/FeedCard.jsx
+++ b/src/main/front/src/components/FeedCard.jsx
@@ -22,6 +22,7 @@ import { useSetRecoilState } from "recoil";
 import { feedCountAtom } from "../recoil/feedAtom";
 import ShareModal from "./modals/ShareModal";
 import HistoryModal from "./modals/HistoryModal";
+import FeedCardTags from "./FeedCardTags";
 
 export default function FeedCard({ loading, item, watchSeen = false }) {
   const fetch = useFetchBe();
@@ -168,6 +169,7 @@ export default function FeedCard({ loading, item, watchSeen = false }) {
               <ReactShowMoreText lines={3} truncatedEndingComponent="">
                 {convertTextToLinks(item.content.trim())}
               </ReactShowMoreText>
+              <FeedCardTags tags={item.tags} />
             </CardContent>
             {/* <CardActions disableSpacing>
         <IconButton aria-label="add to favorites">

--- a/src/main/front/src/components/FeedCardTags.jsx
+++ b/src/main/front/src/components/FeedCardTags.jsx
@@ -4,29 +4,21 @@ import React from "react";
 function FeedCardTags({ tags }) {
   const theme = useTheme();
   return (
-    <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
-      {tags && tags.length > 0 && (
-        <div
-          style={{
-            display: "flex",
-            flexWrap: "wrap",
-            marginTop: "8px",
-          }}
-        >
-          {tags.map((tag) => (
-            <Chip
-              key={tag.code}
-              label={`#${tag.label}`}
-              sx={{
-                color: theme.palette.getContrastText(`#${tag.colorHex}`),
-                backgroundColor: `#${tag.colorHex}`,
-              }}
-              // color={tag.colorHex}
-              size="small"
-            />
-          ))}
-        </div>
-      )}
+    <Stack direction="row" spacing={1} sx={{ pt: 2 }}>
+      {tags &&
+        tags.length > 0 &&
+        tags.map((tag) => (
+          <Chip
+            key={tag.code}
+            label={`#${tag.label}`}
+            sx={{
+              color: theme.palette.getContrastText(`#${tag.colorHex}`),
+              backgroundColor: `#${tag.colorHex}`,
+            }}
+            // color={tag.colorHex}
+            size="small"
+          />
+        ))}
     </Stack>
   );
 }

--- a/src/main/front/src/components/FeedCardTags.jsx
+++ b/src/main/front/src/components/FeedCardTags.jsx
@@ -3,7 +3,6 @@ import React from "react";
 
 function FeedCardTags({ tags }) {
   const theme = useTheme();
-  console.log(tags);
   return (
     <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
       {tags && tags.length > 0 && (

--- a/src/main/front/src/components/FeedCardTags.jsx
+++ b/src/main/front/src/components/FeedCardTags.jsx
@@ -1,0 +1,35 @@
+import { Chip, Stack, useTheme } from "@mui/material";
+import React from "react";
+
+function FeedCardTags({ tags }) {
+  const theme = useTheme();
+  console.log(tags);
+  return (
+    <Stack direction="row" spacing={1} sx={{ pt: 1 }}>
+      {tags && tags.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexWrap: "wrap",
+            marginTop: "8px",
+          }}
+        >
+          {tags.map((tag) => (
+            <Chip
+              key={tag.code}
+              label={`#${tag.label}`}
+              sx={{
+                color: theme.palette.getContrastText(`#${tag.colorHex}`),
+                backgroundColor: `#${tag.colorHex}`,
+              }}
+              // color={tag.colorHex}
+              size="small"
+            />
+          ))}
+        </div>
+      )}
+    </Stack>
+  );
+}
+
+export default FeedCardTags;

--- a/src/main/front/src/components/FeedCardTags.jsx
+++ b/src/main/front/src/components/FeedCardTags.jsx
@@ -15,7 +15,6 @@ function FeedCardTags({ tags }) {
               color: theme.palette.getContrastText(`#${tag.colorHex}`),
               backgroundColor: `#${tag.colorHex}`,
             }}
-            // color={tag.colorHex}
             size="small"
           />
         ))}

--- a/src/main/front/src/hooks/useLoadData.js
+++ b/src/main/front/src/hooks/useLoadData.js
@@ -44,6 +44,7 @@ const useLoadData = ({ type = "" } = {}) => {
             subjectId: dd.subjectId,
             like: dd.like,
             messageCount: dd.messageCount,
+            tags: dd.tags,
           })),
         ],
         "id"

--- a/src/main/front/src/pages/KafeedDetail.jsx
+++ b/src/main/front/src/pages/KafeedDetail.jsx
@@ -41,6 +41,7 @@ function KafeedDetail() {
             subjectId: doc.subjectId,
             like: doc.like,
             messageCount: doc.messageCount,
+            tags: doc.tags,
           }}
         />
       ) : (

--- a/src/main/java/app/handong/feed/dto/TagDto.java
+++ b/src/main/java/app/handong/feed/dto/TagDto.java
@@ -116,4 +116,14 @@ public class TagDto {
         private String code;
         private String message;
     }
+
+    @Getter
+    @Setter
+    @AllArgsConstructor
+    public static class ReadUserResDto {
+        private String code;
+        private String label;
+        private String userDesc;
+        private String colorHex;
+    }
 }

--- a/src/main/java/app/handong/feed/dto/TbmessageDto.java
+++ b/src/main/java/app/handong/feed/dto/TbmessageDto.java
@@ -20,6 +20,7 @@ public class TbmessageDto {
         private List<String> files;
         private boolean like;
         private int messageCount;
+        private List<TagDto.ReadUserResDto> tags;
     }
 
     @Schema

--- a/src/main/java/app/handong/feed/service/impl/TbKaFeedServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/TbKaFeedServiceImpl.java
@@ -170,6 +170,18 @@ public class TbKaFeedServiceImpl implements TbKaFeedService {
         TbmessageDto.Detail detail = tbmessageMapper.getOneHash(messageId, userId);
         if (detail == null) throw new NotFoundException("GetOne Not Found: " + messageId);
 
+        // <<-- PROCESS THE TAGS -->>
+        List<TagDto.ReadUserResDto> tags = tbSubjectTagRepository.findByTbSubjectId(detail.getSubjectId()).stream().map(subjectTag ->
+                new TagDto.ReadUserResDto(
+                        subjectTag.getTag().getCode(),
+                        subjectTag.getTag().getLabel(),
+                        subjectTag.getTag().getUserDesc(),
+                        subjectTag.getTag().getColorHex()
+                )
+        ).toList();
+        detail.setTags(tags);
+
+        // <<-- PROCESS THE FILE -->>
         // Fetch file details asynchronously
         CompletableFuture<List<TbmessageDto.FileDetail>> fileDetailsFuture = tbmessageMapper.fileDetailsAsync(detail.getId());
 

--- a/src/main/java/app/handong/feed/service/impl/TbKaFeedServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/TbKaFeedServiceImpl.java
@@ -1,10 +1,12 @@
 package app.handong.feed.service.impl;
 
 import app.handong.feed.domain.TbKaFeed;
+import app.handong.feed.dto.TagDto;
 import app.handong.feed.dto.TbmessageDto;
 import app.handong.feed.exception.data.NotFoundException;
 import app.handong.feed.mapper.TbmessageMapper;
 import app.handong.feed.repository.TbKaFeedRepository;
+import app.handong.feed.repository.TbSubjectTagRepository;
 import app.handong.feed.repository.TbUserSearchRepository;
 import app.handong.feed.service.FirebaseService;
 import app.handong.feed.service.ShortHashService;
@@ -24,17 +26,19 @@ public class TbKaFeedServiceImpl implements TbKaFeedService {
     private final FirebaseService firebaseService;
     private final TbUserSearchRepository tbUserSearchRepository;
     private final TbLoggerService tbLoggerService;
+    private final TbSubjectTagRepository tbSubjectTagRepository;
 
     public TbKaFeedServiceImpl(
             TbKaFeedRepository tbKaFeedRepository,
             TbmessageMapper tbmessageMapper,
             FirebaseService firebaseService,
-            TbUserSearchRepository tbUserSearchRepository, TbLoggerService tbLoggerService) {
+            TbUserSearchRepository tbUserSearchRepository, TbLoggerService tbLoggerService, TbSubjectTagRepository tbSubjectTagRepository) {
         this.tbKaFeedRepository = tbKaFeedRepository;
         this.tbmessageMapper = tbmessageMapper;
         this.firebaseService = firebaseService;
         this.tbUserSearchRepository = tbUserSearchRepository;
         this.tbLoggerService = tbLoggerService;
+        this.tbSubjectTagRepository = tbSubjectTagRepository;
     }
 
     public Map<String, Object> create(Map<String, Object> param) {
@@ -94,6 +98,18 @@ public class TbKaFeedServiceImpl implements TbKaFeedService {
         // Process each TbmessageDto.Detail asynchronously
         List<CompletableFuture<TbmessageDto.Detail>> futures = result.stream()
                 .map(message -> {
+                    // <<-- PROCESS THE TAGS -->>
+                    List<TagDto.ReadUserResDto> tags = tbSubjectTagRepository.findByTbSubjectId(message.getSubjectId()).stream().map(subjectTag ->
+                            new TagDto.ReadUserResDto(
+                                    subjectTag.getTag().getCode(),
+                                    subjectTag.getTag().getLabel(),
+                                    subjectTag.getTag().getUserDesc(),
+                                    subjectTag.getTag().getColorHex()
+                            )
+                    ).toList();
+                    message.setTags(tags);
+
+                    // <<-- PROCESS THE FILE -->>
                     // Fetch file details asynchronously
                     CompletableFuture<List<TbmessageDto.FileDetail>> fileDetailsFuture = tbmessageMapper.fileDetailsAsync(message.getId());
 

--- a/src/main/resources/mapper/TbmessageMapper.xml
+++ b/src/main/resources/mapper/TbmessageMapper.xml
@@ -18,7 +18,6 @@
         GROUP BY subject_id
         ) latest
         ON m.subject_id = latest.subject_id AND m.last_sent_at = latest.max_sent_at
-
         LEFT JOIN mydb_TbUserLike likeDB
         ON m.subject_id = likeDB.subjectId AND #{userId} = likeDB.userId
 
@@ -61,7 +60,6 @@
                 )
             </if>
         </where>
-
         ORDER BY m.last_sent_at DESC
         LIMIT 15
     </select>


### PR DESCRIPTION
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **새로운 기능**
    - 피드 카드에 태그가 표시됩니다.
    - 각 피드 항목에 태그 정보가 포함되어 표시됩니다.
    - 태그 정보를 위한 새로운 DTO 및 필드가 백엔드에 추가되었습니다.
    - 새로운 외부 및 관리자 API 응답 구조에 대한 엄격한 검증 테스트가 추가되었습니다.
    - 새로운 피드 상세 조회 API 엔드포인트가 도입되었습니다.

- **버그 수정**
    - 피드 관련 API 응답 구조에 대한 엄격한 검증 테스트가 추가되었습니다.

- **문서**
    - 피드 스크롤 리스트 API의 쿼리 파라미터 타입에 대한 설명이 추가되었습니다.

- **스타일**
    - SQL 매퍼 파일에서 불필요한 공백이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related PR
* resolves #89
* resolves #91