### PR TITLE
Add GET /last-assigned endpoint and update tag-subject JPA relations

### DIFF
--- a/.bruno/Feed/External/tag/Assign Tag to Subject.bru
+++ b/.bruno/Feed/External/tag/Assign Tag to Subject.bru
@@ -1,7 +1,7 @@
 meta {
   name: Assign Tag to Subject
   type: http
-  seq: 8
+  seq: 4
 }
 
 post {

--- a/.bruno/Feed/External/tag/LastAssignByMe.bru
+++ b/.bruno/Feed/External/tag/LastAssignByMe.bru
@@ -1,0 +1,11 @@
+meta {
+  name: LastAssignByMe
+  type: http
+  seq: 2
+}
+
+get {
+  url: http://localhost:{{PORT}}/api/
+  body: none
+  auth: inherit
+}

--- a/.bruno/Feed/External/tag/LastAssignByMe.bru
+++ b/.bruno/Feed/External/tag/LastAssignByMe.bru
@@ -5,7 +5,59 @@ meta {
 }
 
 get {
-  url: http://localhost:{{PORT}}/api/
+  url: http://localhost:{{PORT}}/api/external/subject/last-assigned
   body: none
   auth: inherit
+}
+
+tests {
+  test("should have correct response", function () {
+    const data = res.getBody(); // JSON 객체 하나
+  
+    // 기대되는 필드와 타입 정의
+    const expectedShape = {
+      id: "number",
+      tbSubjectId: "number",
+      tagCode: "string",
+      confidentValue: "number",
+      forDate: "string",
+      createdAt: "string",
+      lastSentAt: "number",
+      lastSentChatId: "number"
+    };
+  
+    // 구조 유효성 검사 함수
+    function validateStructure(obj, shape, path = '') {
+      const actualKeys = Object.keys(obj).sort();
+      const expectedKeys = Object.keys(shape).sort();
+      expect(actualKeys, `Keys at '${path || 'root'}' do not match`).to.eql(expectedKeys);
+  
+      for (const [key, typeOrShape] of Object.entries(shape)) {
+        const fullPath = path ? `${path}.${key}` : key;
+        const value = obj[key];
+  
+        // nullable 필드 처리
+        if (typeof typeOrShape === 'object' && typeOrShape.nullable) {
+          if (value === null) continue;
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape.type} or null`).to.be.a(typeOrShape.type);
+        }
+  
+        // 기본 타입 검사
+        else if (typeof typeOrShape === 'string') {
+          expect(value, `Field '${fullPath}' should be a ${typeOrShape}`).to.be.a(typeOrShape);
+        }
+  
+        // 중첩 객체 검사
+        else {
+          expect(value, `Field '${fullPath}' should be an object`).to.be.a('object');
+          validateStructure(value, typeOrShape, fullPath);
+        }
+      }
+    }
+  
+    // 객체 검사 실행
+    expect(data).to.be.an('object');
+    validateStructure(data, expectedShape);
+  });
+  
 }

--- a/src/main/java/app/handong/feed/TablePrefix.java
+++ b/src/main/java/app/handong/feed/TablePrefix.java
@@ -4,6 +4,8 @@ import org.hibernate.boot.model.naming.Identifier;
 import org.hibernate.boot.model.naming.PhysicalNamingStrategy;
 import org.hibernate.engine.jdbc.env.spi.JdbcEnvironment;
 
+import java.util.Set;
+
 public class TablePrefix implements PhysicalNamingStrategy {
 
     private final String tablePrefix = "mydb_";
@@ -20,9 +22,12 @@ public class TablePrefix implements PhysicalNamingStrategy {
 
     @Override
     public Identifier toPhysicalTableName(Identifier name, JdbcEnvironment context) {
+        // 예외 목록 설정
+        if (name != null && EXCLUDED_TABLES.contains(name.getText())) {
+            return name; // prefix 붙이지 않음
+        }
         return applyPrefix(name);
     }
-
     @Override
     public Identifier toPhysicalSequenceName(Identifier name, JdbcEnvironment context) {
         return applyPrefix(name);
@@ -40,4 +45,9 @@ public class TablePrefix implements PhysicalNamingStrategy {
         String newName = tablePrefix + identifier.getText();
         return Identifier.toIdentifier(newName);
     }
+
+    // 예외 테이블 리스트
+    private static final Set<String> EXCLUDED_TABLES = Set.of(
+            "TbSubject"// prefix 없이 사용하고 싶은 테이블
+    );
 }

--- a/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
+++ b/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
@@ -19,6 +19,13 @@ import java.util.List;
 public class SubjectExternalApiController {
     private final ExternalSubjectService externalSubjectService;
 
+    @GetMapping("/last-assigned")
+    @Operation(summary = "내가 마지막으로 추가한 서브젝트 확인")
+    public ResponseEntity<TbSubjectTagDto.CreateResDto> getMyLastCreatedTagAssign (HttpServletRequest request) {
+        String reqApiId = RequestUtils.getReqApiId(request);
+        return ResponseEntity.ok(externalSubjectService.getLastSubjectAssign(reqApiId));
+    }
+
     @PostMapping("/{subjectId}/tag-assign")
     @Operation(summary = "서브젝트에 태그 추가")
     @RequiredApiScopes({"tag_assign:write"})
@@ -54,7 +61,9 @@ public class SubjectExternalApiController {
                         dto.getTagCode(),
                         dto.getConfidentValue(),
                         dto.getForDate(),
-                        null // 생성 시간 없음
+                        null, // 생성 시간 없음
+                        null,
+                        null
                 );
             }
         }).toList());

--- a/src/main/java/app/handong/feed/domain/TbSubject.java
+++ b/src/main/java/app/handong/feed/domain/TbSubject.java
@@ -1,0 +1,35 @@
+package app.handong.feed.domain;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.ToString;
+import org.hibernate.annotations.Immutable;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "TbSubject")
+@Getter
+@ToString
+@Immutable // 완전 불변 객체로 간주 (Hibernate 전용)
+public class TbSubject {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "last_sent_at")
+    private Integer lastSentAt;
+
+    @Column(name = "last_sent_chat_id")
+    private Long lastSentChatId;
+
+    @Column(name = "deleted")
+    private String deleted;
+}

--- a/src/main/java/app/handong/feed/domain/TbSubjectTag.java
+++ b/src/main/java/app/handong/feed/domain/TbSubjectTag.java
@@ -91,6 +91,8 @@ public class TbSubjectTag {
     }
 
     public TbSubjectTagDto.CreateResDto toCreateResDto() {
+        Integer lastSentAt = tbSubject != null ? tbSubject.getLastSentAt() : null;
+        Long lastSentChatId = tbSubject != null ? tbSubject.getLastSentChatId() : null;
         return new TbSubjectTagDto.CreateResDto(
                 id,
                 tbSubjectId,
@@ -98,8 +100,8 @@ public class TbSubjectTag {
                 confidentValue,
                 forDate,
                 createdAt,
-                tbSubject.getLastSentAt(),
-                tbSubject.getLastSentChatId()
+                lastSentAt,
+                lastSentChatId
         );
     }
 }

--- a/src/main/java/app/handong/feed/domain/TbSubjectTag.java
+++ b/src/main/java/app/handong/feed/domain/TbSubjectTag.java
@@ -1,5 +1,6 @@
 package app.handong.feed.domain;
 
+import app.handong.feed.dto.TbSubjectTagDto;
 import jakarta.persistence.*;
 import lombok.Getter;
 import org.springframework.data.annotation.CreatedDate;
@@ -30,6 +31,16 @@ public class TbSubjectTag {
 
     @Column(name = "tb_subject_id", nullable = false)
     private int tbSubjectId;
+
+    @ManyToOne
+    @JoinColumn(
+            name = "tb_subject_id",
+            referencedColumnName = "id",
+            insertable = false,
+            updatable = false,
+            foreignKey = @ForeignKey(ConstraintMode.NO_CONSTRAINT)
+    )
+    private TbSubject tbSubject;
 
     @Column(name = "tag_code", length = 32, nullable = false)
     private String tagCode; // Tag.code 참조 (FK는 명시적으로 걸지 않음)
@@ -77,5 +88,18 @@ public class TbSubjectTag {
 
     public static TbSubjectTag of(int tbSubjectId, String tagCode, float confidentValue, LocalDate forDate, String updatedBy, String updatedByType) {
         return new TbSubjectTag(tbSubjectId, tagCode, confidentValue, forDate, updatedBy, updatedByType);
+    }
+
+    public TbSubjectTagDto.CreateResDto toCreateResDto() {
+        return new TbSubjectTagDto.CreateResDto(
+                id,
+                tbSubjectId,
+                tagCode,
+                confidentValue,
+                forDate,
+                createdAt,
+                tbSubject.getLastSentAt(),
+                tbSubject.getLastSentChatId()
+        );
     }
 }

--- a/src/main/java/app/handong/feed/dto/TbSubjectTagDto.java
+++ b/src/main/java/app/handong/feed/dto/TbSubjectTagDto.java
@@ -62,6 +62,8 @@ public class TbSubjectTagDto {
         private float confidentValue;
         private LocalDate forDate;
         private LocalDateTime createdAt;
+        private Integer lastSentAt;
+        private Long lastSentChatId;
     }
 
     @Getter

--- a/src/main/java/app/handong/feed/repository/TbSubjectRepository.java
+++ b/src/main/java/app/handong/feed/repository/TbSubjectRepository.java
@@ -1,0 +1,8 @@
+package app.handong.feed.repository;
+
+import app.handong.feed.domain.TbSubject;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TbSubjectRepository extends JpaRepository<TbSubject, Long> {
+
+}

--- a/src/main/java/app/handong/feed/repository/TbSubjectTagRepository.java
+++ b/src/main/java/app/handong/feed/repository/TbSubjectTagRepository.java
@@ -21,4 +21,7 @@ public interface TbSubjectTagRepository extends JpaRepository<TbSubjectTag, Inte
 
     // subjectId, tagId 조합 존재 여부 확인 (복합키 유니크 체크에 유용)
     boolean existsByTbSubjectIdAndTagCode(int tbSubjectId, String tagCode);
+
+    Optional<TbSubjectTag> findTopByUpdatedByOrderByCreatedAt(String updated_by);
+
 }

--- a/src/main/java/app/handong/feed/service/ExternalSubjectService.java
+++ b/src/main/java/app/handong/feed/service/ExternalSubjectService.java
@@ -5,5 +5,7 @@ import org.springframework.stereotype.Service;
 
 @Service
 public interface ExternalSubjectService {
-    public TbSubjectTagDto.CreateResDto createSubjectTag(TbSubjectTagDto.CreateReqDto dto);
+
+    TbSubjectTagDto.CreateResDto createSubjectTag(TbSubjectTagDto.CreateReqDto dto);
+    TbSubjectTagDto.CreateResDto getLastSubjectAssign(String updated_by);
 }

--- a/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
@@ -1,6 +1,5 @@
 package app.handong.feed.service.impl;
 
-import app.handong.feed.domain.TbSubject;
 import app.handong.feed.domain.TbSubjectTag;
 import app.handong.feed.dto.TbSubjectTagDto;
 import app.handong.feed.exception.data.DuplicateEntityException;
@@ -40,10 +39,6 @@ public class ExternalSubjectServiceImpl implements ExternalSubjectService {
 
     @Override
     public TbSubjectTagDto.CreateResDto getLastSubjectAssign(String updated_by) {
-        TbSubjectTagDto.CreateResDto result = tbSubjectTagRepository.findTopByUpdatedByOrderByCreatedAt(updated_by).orElseThrow(() -> new NotFoundException("Not Found")).toCreateResDto();
-        TbSubject tbSubject = tbSubjectRepository.findById(Long.valueOf(result.getTbSubjectId() + "")).orElseThrow(() -> new NotFoundException("Not Found" + result.getTbSubjectId()));
-        result.setLastSentAt(tbSubject.getLastSentAt());
-        result.setLastSentChatId(tbSubject.getLastSentChatId());
-        return result;
+        return tbSubjectTagRepository.findTopByUpdatedByOrderByCreatedAt(updated_by).orElseThrow(() -> new NotFoundException("Not Found")).toCreateResDto();
     }
 }

--- a/src/main/java/app/handong/feed/service/impl/TbSubjectTagServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/TbSubjectTagServiceImpl.java
@@ -25,14 +25,7 @@ public class TbSubjectTagServiceImpl implements TbSubjectTagService {
 
         try {
             TbSubjectTag saved = subjectTagRepository.save(dto.toEntity());
-            return new TbSubjectTagDto.CreateResDto(
-                    saved.getId(),
-                    saved.getTbSubjectId(),
-                    saved.getTagCode(),
-                    saved.getConfidentValue(),
-                    saved.getForDate(),
-                    saved.getCreatedAt()
-            );
+            return saved.toCreateResDto();
         } catch (DataIntegrityViolationException e) {
             throw new DuplicateEntityException("duplicate tag code: " + dto.getTagCode());
         }


### PR DESCRIPTION
## 수정사항

새로운 tag assign 시 해당 subject 정보인 lastSentAt, lastSentChatId 반환

## 새로 추가된 endpoint

### GET /api/external/subject/last-assigned

해당 api 키로 마지막으로 추가한 subject tag assign.

마지막으로 받은 `/api/external/subject/:subjectId/tag-assign` 응답하고 같습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **신규 기능**
    - 최근에 생성한 과목 태그 할당 정보를 조회할 수 있는 새로운 API 엔드포인트가 추가되었습니다.
    - 새로운 엔티티 및 저장소가 도입되어 과목 정보를 관리할 수 있습니다.
- **버그 수정**
    - 과목 태그 응답 데이터에 최근 발송 시각 및 채팅 ID 정보가 추가되었습니다.
- **리팩터**
    - 응답 객체 생성 방식이 간소화되어 코드가 개선되었습니다.
- **기타**
    - 일부 내부 시퀀스 및 테이블 처리 방식이 조정되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Related PR
* resolves #136