### PR TITLE
[BE/FEAT] 주제 태그 할당 완료 상태 업데이트 기능 추가

### DIFF
--- a/.bruno/External/subject/folder.bru
+++ b/.bruno/External/subject/folder.bru
@@ -1,0 +1,3 @@
+meta {
+  name: subject
+}

--- a/.bruno/External/subject/update IsTagAssigned True.bru
+++ b/.bruno/External/subject/update IsTagAssigned True.bru
@@ -1,0 +1,15 @@
+meta {
+  name: update IsTagAssigned True
+  type: http
+  seq: 1
+}
+
+patch {
+  url: http://localhost:{{PORT}}/api/external/subject/:subjectId/tag-assigned
+  body: none
+  auth: inherit
+}
+
+params:path {
+  subjectId: 1
+}

--- a/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
+++ b/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
@@ -1,0 +1,25 @@
+package app.handong.feed.controller.external;
+
+import app.handong.feed.security.annotation.RequiredApiScopes;
+import app.handong.feed.service.ExternalSubjectService;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/external/subject")
+@RequiredArgsConstructor
+public class SubjectExternalApiController {
+    private final ExternalSubjectService externalSubjectService;
+
+    @PatchMapping("/{subjectId}/tag-assigned")
+    @Operation(summary = "주제 ID를 기반으로 태그 할당 완료 상태로 갱신합니다.")
+    @RequiredApiScopes({"tag_assign:write"})
+    public ResponseEntity<Void> updateIsTagAssignedTrue(
+            @PathVariable long subjectId
+    ) {
+        externalSubjectService.updateIsTagAssignedTrue(subjectId);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
+++ b/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
@@ -3,6 +3,8 @@ package app.handong.feed.controller.external;
 import app.handong.feed.security.annotation.RequiredApiScopes;
 import app.handong.feed.service.ExternalSubjectService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -13,6 +15,12 @@ import org.springframework.web.bind.annotation.*;
 public class SubjectExternalApiController {
     private final ExternalSubjectService externalSubjectService;
 
+
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "204", description = "태그 할당 상태가 성공적으로 업데이트됨"),
+            @ApiResponse(responseCode = "404", description = "지정된 ID의 주제를 찾을 수 없음"),
+            @ApiResponse(responseCode = "403", description = "API 접근 권한 없음")
+    })
     @PatchMapping("/{subjectId}/tag-assigned")
     @Operation(summary = "주제 ID를 기반으로 태그 할당 완료 상태로 갱신합니다.")
     @RequiredApiScopes({"tag_assign:write"})

--- a/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
+++ b/src/main/java/app/handong/feed/controller/external/SubjectExternalApiController.java
@@ -27,6 +27,10 @@ public class SubjectExternalApiController {
     public ResponseEntity<Void> updateIsTagAssignedTrue(
             @PathVariable long subjectId
     ) {
+
+        if (subjectId <= 0) {
+            return ResponseEntity.badRequest().build();
+        }
         externalSubjectService.updateIsTagAssignedTrue(subjectId);
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/app/handong/feed/mapper/TbsubjectMapper.java
+++ b/src/main/java/app/handong/feed/mapper/TbsubjectMapper.java
@@ -12,4 +12,6 @@ public interface TbsubjectMapper {
     TbsubjectDto.LastMessageServDto getLastMessageByMessageId(String lastMessageId);
 
     List<TbsubjectDto.MessageHistoryServDto> getMessageHistoryById(Long subjectId);
+
+    void updateIsTagAssignedTrue(Long id);
 }

--- a/src/main/java/app/handong/feed/mapper/TbsubjectMapper.java
+++ b/src/main/java/app/handong/feed/mapper/TbsubjectMapper.java
@@ -13,5 +13,5 @@ public interface TbsubjectMapper {
 
     List<TbsubjectDto.MessageHistoryServDto> getMessageHistoryById(Long subjectId);
 
-    void updateIsTagAssignedTrue(Long id);
+    int updateIsTagAssignedTrue(Long id);
 }

--- a/src/main/java/app/handong/feed/mapper/TbsubjectMapper.java
+++ b/src/main/java/app/handong/feed/mapper/TbsubjectMapper.java
@@ -13,5 +13,9 @@ public interface TbsubjectMapper {
 
     List<TbsubjectDto.MessageHistoryServDto> getMessageHistoryById(Long subjectId);
 
+    /**
+     * 주제의 태그 할당 상태를 완료(true)로 업데이트합니다.
+     * @param id 대상 주제의 ID
+     */
     int updateIsTagAssignedTrue(Long id);
 }

--- a/src/main/java/app/handong/feed/service/ExternalFeedService.java
+++ b/src/main/java/app/handong/feed/service/ExternalFeedService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service
+
 public interface ExternalFeedService {
     List<TbmessageDto.Detail> getFeedBetween(Long startTimestamp, Long endTimestamp, boolean isNew, Integer limit);
     List<TbmessageDto.Detail> getFeedBetween(ExternalDto.FeedReqDto dto);

--- a/src/main/java/app/handong/feed/service/ExternalFeedService.java
+++ b/src/main/java/app/handong/feed/service/ExternalFeedService.java
@@ -2,7 +2,6 @@ package app.handong.feed.service;
 
 import app.handong.feed.dto.ExternalDto;
 import app.handong.feed.dto.TbmessageDto;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 

--- a/src/main/java/app/handong/feed/service/ExternalSubjectService.java
+++ b/src/main/java/app/handong/feed/service/ExternalSubjectService.java
@@ -1,7 +1,5 @@
 package app.handong.feed.service;
 
-import org.springframework.stereotype.Service;
-
 
 public interface ExternalSubjectService {
     void updateIsTagAssignedTrue(Long subjectId);

--- a/src/main/java/app/handong/feed/service/ExternalSubjectService.java
+++ b/src/main/java/app/handong/feed/service/ExternalSubjectService.java
@@ -2,7 +2,7 @@ package app.handong.feed.service;
 
 import org.springframework.stereotype.Service;
 
-@Service
+
 public interface ExternalSubjectService {
     void updateIsTagAssignedTrue(Long subjectId);
 }

--- a/src/main/java/app/handong/feed/service/ExternalSubjectService.java
+++ b/src/main/java/app/handong/feed/service/ExternalSubjectService.java
@@ -1,0 +1,8 @@
+package app.handong.feed.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public interface ExternalSubjectService {
+    void updateIsTagAssignedTrue(Long subjectId);
+}

--- a/src/main/java/app/handong/feed/service/ExternalSubjectTagService.java
+++ b/src/main/java/app/handong/feed/service/ExternalSubjectTagService.java
@@ -1,7 +1,6 @@
 package app.handong.feed.service;
 
 import app.handong.feed.dto.TbSubjectTagDto;
-import org.springframework.stereotype.Service;
 
 
 public interface ExternalSubjectTagService {

--- a/src/main/java/app/handong/feed/service/ExternalSubjectTagService.java
+++ b/src/main/java/app/handong/feed/service/ExternalSubjectTagService.java
@@ -3,7 +3,7 @@ package app.handong.feed.service;
 import app.handong.feed.dto.TbSubjectTagDto;
 import org.springframework.stereotype.Service;
 
-@Service
+
 public interface ExternalSubjectTagService {
     TbSubjectTagDto.CreateResDto createSubjectTag(TbSubjectTagDto.CreateReqDto dto);
     TbSubjectTagDto.GetLatestForDateResDto readLatestForDate();

--- a/src/main/java/app/handong/feed/service/TagService.java
+++ b/src/main/java/app/handong/feed/service/TagService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service
+
 public interface TagService {
     TagDto.ReadResDto readTag(String code);
     List<TagDto.ReadResDto> readAllTags();

--- a/src/main/java/app/handong/feed/service/TagService.java
+++ b/src/main/java/app/handong/feed/service/TagService.java
@@ -1,7 +1,6 @@
 package app.handong.feed.service;
 
 import app.handong.feed.dto.TagDto;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 

--- a/src/main/java/app/handong/feed/service/TbKaFeedService.java
+++ b/src/main/java/app/handong/feed/service/TbKaFeedService.java
@@ -1,7 +1,6 @@
 package app.handong.feed.service;
 
 import app.handong.feed.dto.TbmessageDto;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/app/handong/feed/service/TbKaFeedService.java
+++ b/src/main/java/app/handong/feed/service/TbKaFeedService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 
-@Service
+
 public interface TbKaFeedService {
     public Map<String, Object> create(Map<String, Object> param);
 

--- a/src/main/java/app/handong/feed/service/TbSubjectTagService.java
+++ b/src/main/java/app/handong/feed/service/TbSubjectTagService.java
@@ -1,7 +1,6 @@
 package app.handong.feed.service;
 
 import app.handong.feed.dto.TbSubjectTagDto;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 

--- a/src/main/java/app/handong/feed/service/TbSubjectTagService.java
+++ b/src/main/java/app/handong/feed/service/TbSubjectTagService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.List;
 
-@Service
+
 public interface TbSubjectTagService {
     TbSubjectTagDto.CreateResDto createSubjectTag(TbSubjectTagDto.CreateReqDto dto);
     List<TbSubjectTagDto.ReadResDto> readSubjectTags(int subjectId);

--- a/src/main/java/app/handong/feed/service/TbadminService.java
+++ b/src/main/java/app/handong/feed/service/TbadminService.java
@@ -2,7 +2,6 @@ package app.handong.feed.service;
 
 import app.handong.feed.dto.TagDto;
 import app.handong.feed.dto.TbadminDto;
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/app/handong/feed/service/TbadminService.java
+++ b/src/main/java/app/handong/feed/service/TbadminService.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 
-@Service
+
 public interface TbadminService {
     public List<TbadminDto.UserDetail> adminGetUser(String userId, Map<String, String> param);
 

--- a/src/main/java/app/handong/feed/service/TbfeedService.java
+++ b/src/main/java/app/handong/feed/service/TbfeedService.java
@@ -5,7 +5,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.Map;
 
-@Service
+
 public interface TbfeedService {
     public Map<String, Object> create(Map<String, Object> param);
     public Map<String, Object> update(Map<String, Object> param);

--- a/src/main/java/app/handong/feed/service/TbfeedService.java
+++ b/src/main/java/app/handong/feed/service/TbfeedService.java
@@ -1,6 +1,5 @@
 package app.handong.feed.service;
 
-import org.springframework.stereotype.Service;
 
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/app/handong/feed/service/TbsubjectService.java
+++ b/src/main/java/app/handong/feed/service/TbsubjectService.java
@@ -5,7 +5,6 @@ import app.handong.feed.dto.TbsubjectDto;
 import org.springframework.stereotype.Service;
 
 
-@Service
 public interface TbsubjectService {
 
     TbsubjectDto.DetailResDto getDetail(TbsubjectDto.DetailReqDto param);

--- a/src/main/java/app/handong/feed/service/TbsubjectService.java
+++ b/src/main/java/app/handong/feed/service/TbsubjectService.java
@@ -2,7 +2,6 @@ package app.handong.feed.service;
 
 
 import app.handong.feed.dto.TbsubjectDto;
-import org.springframework.stereotype.Service;
 
 
 public interface TbsubjectService {

--- a/src/main/java/app/handong/feed/service/TbuserService.java
+++ b/src/main/java/app/handong/feed/service/TbuserService.java
@@ -2,7 +2,6 @@ package app.handong.feed.service;
 
 import app.handong.feed.dto.DefaultDto;
 import app.handong.feed.dto.TbuserDto;
-import org.springframework.stereotype.Service;
 
 import java.util.Map;
 

--- a/src/main/java/app/handong/feed/service/TbuserService.java
+++ b/src/main/java/app/handong/feed/service/TbuserService.java
@@ -6,7 +6,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.Map;
 
-@Service
+
 public interface TbuserService {
 
 

--- a/src/main/java/app/handong/feed/service/UserInteractionService.java
+++ b/src/main/java/app/handong/feed/service/UserInteractionService.java
@@ -3,7 +3,7 @@ package app.handong.feed.service;
 import app.handong.feed.dto.UserInteractionDto;
 import org.springframework.stereotype.Service;
 
-@Service
+
 public interface UserInteractionService {
 
 

--- a/src/main/java/app/handong/feed/service/UserInteractionService.java
+++ b/src/main/java/app/handong/feed/service/UserInteractionService.java
@@ -1,7 +1,6 @@
 package app.handong.feed.service;
 
 import app.handong.feed.dto.UserInteractionDto;
-import org.springframework.stereotype.Service;
 
 
 public interface UserInteractionService {

--- a/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
@@ -1,5 +1,6 @@
 package app.handong.feed.service.impl;
 
+import app.handong.feed.exception.data.NotFoundException;
 import app.handong.feed.mapper.TbsubjectMapper;
 import app.handong.feed.service.ExternalSubjectService;
 import jakarta.transaction.Transactional;
@@ -16,6 +17,10 @@ public class ExternalSubjectServiceImpl implements ExternalSubjectService {
     @Override
     @Transactional
     public void updateIsTagAssignedTrue(Long subjectId) {
-        tbsubjectMapper.updateIsTagAssignedTrue(subjectId);
+        int updatedRows = tbsubjectMapper.updateIsTagAssignedTrue(subjectId);
+        // 영향을 받은 Row 가 0개라면 존재하지 않는 Subject에 대한 요청임.
+        if (updatedRows == 0) {
+            throw new NotFoundException("Subject not found with ID: " + subjectId);
+        }
     }
 }

--- a/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
@@ -4,15 +4,14 @@ import app.handong.feed.exception.data.NotFoundException;
 import app.handong.feed.mapper.TbsubjectMapper;
 import app.handong.feed.service.ExternalSubjectService;
 import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class ExternalSubjectServiceImpl implements ExternalSubjectService {
     private final TbsubjectMapper tbsubjectMapper;
 
-    public ExternalSubjectServiceImpl(TbsubjectMapper tbsubjectMapper) {
-        this.tbsubjectMapper = tbsubjectMapper;
-    }
 
     @Override
     @Transactional

--- a/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
@@ -12,7 +12,11 @@ import org.springframework.stereotype.Service;
 public class ExternalSubjectServiceImpl implements ExternalSubjectService {
     private final TbsubjectMapper tbsubjectMapper;
 
-
+    /**
+     * 주어진 주제(subject)의 태그 할당 상태를 완료(true)로 업데이트합니다.
+     *
+     * @param subjectId 업데이트할 주제의 ID
+     */
     @Override
     @Transactional
     public void updateIsTagAssignedTrue(Long subjectId) {

--- a/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
+++ b/src/main/java/app/handong/feed/service/impl/ExternalSubjectServiceImpl.java
@@ -1,0 +1,21 @@
+package app.handong.feed.service.impl;
+
+import app.handong.feed.mapper.TbsubjectMapper;
+import app.handong.feed.service.ExternalSubjectService;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ExternalSubjectServiceImpl implements ExternalSubjectService {
+    private final TbsubjectMapper tbsubjectMapper;
+
+    public ExternalSubjectServiceImpl(TbsubjectMapper tbsubjectMapper) {
+        this.tbsubjectMapper = tbsubjectMapper;
+    }
+
+    @Override
+    @Transactional
+    public void updateIsTagAssignedTrue(Long subjectId) {
+        tbsubjectMapper.updateIsTagAssignedTrue(subjectId);
+    }
+}

--- a/src/main/resources/mapper/TbsubjectMapper.xml
+++ b/src/main/resources/mapper/TbsubjectMapper.xml
@@ -43,7 +43,8 @@
     <!-- 주제 태그 할당 완료처리 쿼리 -->
     <update id="updateIsTagAssignedTrue">
         UPDATE TbSubject
-        SET is_tag_assigned = 1
+        SET is_tag_assigned = 1,
+            updated_at = NOW()
         WHERE id = #{id}
     </update>
 </mapper>

--- a/src/main/resources/mapper/TbsubjectMapper.xml
+++ b/src/main/resources/mapper/TbsubjectMapper.xml
@@ -40,5 +40,10 @@
         ORDER BY last_sent_at DESC
     </select>
 
-
+    <!-- 주제 태그 할당 완료처리 쿼리 -->
+    <update id="updateIsTagAssignedTrue">
+        UPDATE TbSubject
+        SET is_tag_assigned = 1
+        WHERE id = #{id}
+    </update>
 </mapper>


### PR DESCRIPTION
## 주요 변경사항
•	TbsubjectMapper에 주제(Subject)의 is_tag_assigned 값을 true로 업데이트하는 쿼리 추가
•	ExternalSubjectService 및 ExternalSubjectServiceImpl 생성하여 서비스 레이어 분리
•	SubjectExternalApiController 추가
•	주제 ID를 받아 is_tag_assigned를 true로 업데이트하는 외부 API 제공
•	PATCH /api/external/subject/{subjectId}/tag-assigned 엔드포인트 구현
•	Bruno: /external/subject 디렉토리 구조 정리 및 관련 클래스 이동
•	subjectId 파라미터에 대한 유효성 검증 추가 (0 이하 값에 대해 400 Bad Request 반환)
•	Swagger 문서에 API 응답 코드(204, 404, 403) 명시 추가
•	사용하지 않는 import org.springframework.stereotype.Service 제거하여 Checkstyle 에러 수정

## 추가 설명
•	성공 시 204 No Content 반환 (별도의 응답 데이터 없이 완료 처리)
•	주제 ID가 유효하지 않거나 존재하지 않는 경우 400 또는 404 에러 반환
•	API 호출 시 tag_assign:write 스코프 권한 필요
•	트랜잭션 처리(@Transactional)를 통해 데이터 일관성 보장
•	코드 품질 유지를 위해 불필요한 어노테이션 및 import 정리

## 관련 이슈
https://github.com/handong-app/handong-feed-app/issues/84
https://github.com/handong-app/handong-feed-app/issues/142

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **신규 기능**
    - 외부 API를 통해 과목의 태그 할당 상태를 true로 업데이트하는 PATCH 엔드포인트가 추가되었습니다.
- **기타**
    - 태그 할당 상태 업데이트를 위한 내부 서비스 및 매퍼 로직이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->