### PR TITLE
[Docs] MIT LICENSE 파일 생성 (영문 원본 및 국문 번역 포함)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,39 @@
+MIT License
+
+Copyright (c) 2024-2025 Handong Feed App contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+---
+
+(이하는 이해를 돕기 위한 한국어 번역이며, 법적 효력은 영문 원문을 기준으로 합니다.)
+
+MIT 라이선스
+
+Copyright (c) 2024-2025 Handong Feed App contributors
+
+본 소프트웨어 및 관련 문서 파일(이하 "소프트웨어")의 사본을 획득하는 모든 사람에게,
+소프트웨어를 제한 없이 사용, 복사, 수정, 병합, 게시, 배포, 서브라이선스 및/또는 판매할 수 있는 권한을 무료로 부여합니다.
+소프트웨어를 받은 자도 동일한 권한을 행사할 수 있습니다.
+단, 위 저작권 고지와 이 권한 고지는 소프트웨어의 모든 복제물 또는 실질적인 부분에 포함되어야 합니다.
+
+이 소프트웨어는 "있는 그대로" 제공되며, 상품성, 특정 목적에의 적합성 및 비침해에 대한
+명시적이거나 묵시적인 어떠한 보증도 제공하지 않습니다.
+작성자 또는 저작권 보유자는 계약, 불법행위 또는 기타 행위로 인해 발생한 손해나 기타 책임에 대해 책임을 지지 않습니다.
+이는 소프트웨어 또는 소프트웨어의 사용 또는 기타 거래로 인해 발생한 경우에도 마찬가지입니다.

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024-2025 Handong Feed App contributors
+Copyright (c) 2024-2025 Handong Feed App Contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -22,11 +22,12 @@ SOFTWARE.
 
 ---
 
-(이하는 이해를 돕기 위한 한국어 번역이며, 법적 효력은 영문 원문을 기준으로 합니다.)
+## 한국어 번역 (참고용)
+**본 번역문은 이해를 돕기 위한 참고용으로만 제공되며, 법적 효력은 영문 원문이 우선합니다.**
 
 MIT 라이선스
 
-Copyright (c) 2024-2025 Handong Feed App contributors
+Copyright (c) 2024-2025 Handong Feed App  Contributors
 
 본 소프트웨어 및 관련 문서 파일(이하 "소프트웨어")의 사본을 획득하는 모든 사람에게,
 소프트웨어를 제한 없이 사용, 복사, 수정, 병합, 게시, 배포, 서브라이선스 및/또는 판매할 수 있는 권한을 무료로 부여합니다.


### PR DESCRIPTION
## 📌 관련 이슈
Closes #155 

___

## ✨ 작업 내용
- `LICENSE` 파일 추가 (MIT 라이선스 적용)
- 영문 원문 + 한글 번역 병기 구성

___

## 🔎 세부 설명
- MIT 라이선스 원문을 먼저 작성하고, 이해를 돕기 위한 **비공식 한국어 번역**을 하단에 병기함
- 한국어 번역 상단에는 다음 문구를 명시:
  > (이하는 이해를 돕기 위한 한국어 번역이며, 법적 효력은 영문 원문을 기준으로 합니다.)

___

## 🧪 테스트
- [x] LICENSE 파일 정상적으로 루트 디렉터리에 위치함
- [x] GitHub 상에서 라이선스 자동 인식(MIT) 확인

___

## 📁 변경된 파일/폴더
- `LICENSE`

___

## ➕ 기타
- 추후 README 하단에 "Licensed under the MIT License" 문구도 추가 예정

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - MIT 라이선스 전문이 추가되었습니다.
  - 참고용 한국어 번역이 포함되어 있으며, 법적 효력은 영어 원문에 있음을 명시합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->