### PR TITLE
📝 docs: update LICENSE to English-only for GitHub license detection

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -19,22 +19,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
-
----
-
-## 한국어 번역 (참고용)
-**본 번역문은 이해를 돕기 위한 참고용으로만 제공되며, 법적 효력은 영문 원문이 우선합니다.**
-
-MIT 라이선스
-
-Copyright (c) 2024-2025 Handong Feed App  Contributors
-
-본 소프트웨어 및 관련 문서 파일(이하 "소프트웨어")의 사본을 획득하는 모든 사람에게,
-소프트웨어를 제한 없이 사용, 복사, 수정, 병합, 게시, 배포, 서브라이선스 및/또는 판매할 수 있는 권한을 무료로 부여합니다.
-소프트웨어를 받은 자도 동일한 권한을 행사할 수 있습니다.
-단, 위 저작권 고지와 이 권한 고지는 소프트웨어의 모든 복제물 또는 실질적인 부분에 포함되어야 합니다.
-
-이 소프트웨어는 "있는 그대로" 제공되며, 상품성, 특정 목적에의 적합성 및 비침해에 대한
-명시적이거나 묵시적인 어떠한 보증도 제공하지 않습니다.
-작성자 또는 저작권 보유자는 계약, 불법행위 또는 기타 행위로 인해 발생한 손해나 기타 책임에 대해 책임을 지지 않습니다.
-이는 소프트웨어 또는 소프트웨어의 사용 또는 기타 거래로 인해 발생한 경우에도 마찬가지입니다.


### PR DESCRIPTION
## 📌 관련 이슈
없음

___

## ✨ 작업 내용
- LICENSE 파일에서 한국어 번역을 제거하고 영문 원문만 유지
- GitHub의 자동 라이선스 인식을 위해 포맷 수정

___

## 🔎 세부 설명
- 기존 LICENSE 파일은 MIT 라이선스 영문 원문과 한글 번역이 함께 병기되어 있었음
- GitHub가 `LICENSE` 파일을 자동으로 분석해 라이선스 정보를 표기하려면 **영문 원문만 포함**되어야 함
- 따라서, **LICENSE는 영문만 유지하고**, 번역본은 `LICENSE.KO.md` 파일로 분리 예정

___

## 🧪 테스트
- [x] GitHub Repository의 License 항목이 "MIT License"로 자동 인식되는지 확인

___

## 📁 변경된 파일/폴더
- `LICENSE` — 영문 전용으로 수정


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **문서**
  - MIT 라이선스 파일에서 한국어 번역 섹션이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->